### PR TITLE
add jekyll build to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
+
+before_script:
+  - gem install jekyll
+
+script:
+  - npm test
+  - cd docs/ && jekyll build
+
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
This will make sure that none of the examples break and that the docs
are buildable.
