### PR TITLE
filter out files that are not baileyjs in --watch

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -72,10 +72,12 @@ function startWatching () {
     program.verbose = true;
     console.log('Watching ' + source + ' for changes...');
     watch(source, function(filename) {
-        console.log('\n' + filename + ' changed, recompiling...\n-----------');
-        compile(function(){
-            console.log('-----------\nDone! Looking for more changes...');
-        });
+        if (/(\.bs|\.bailey)$/.test(filename)) {
+            console.log('\n' + filename + ' changed, recompiling...\n-----------');
+            compile(function(){
+                console.log('-----------\nDone! Looking for more changes...');
+            });
+        }
     });
 }
 


### PR DESCRIPTION
This prevents a endless loop of:

```
src/app.js changed, recompiling...
-----------
src/app.bs -> src/app.js
-----------
Done! Looking for more changes...

src/app.js changed, recompiling...
-----------
src/app.bs -> src/app.js
-----------
Done! Looking for more changes...
```
