### PR TITLE
Add support for configuration file

### DIFF
--- a/.baileyrc
+++ b/.baileyrc
@@ -1,0 +1,12 @@
+{
+  "examples": {
+    "source": "examples",
+    "target": "build",
+    "node": true
+  },
+  "tests": {
+    "source": "test",
+    "target": "test",
+    "node": true
+  }
+}

--- a/docs/_includes/usage.md
+++ b/docs/_includes/usage.md
@@ -39,3 +39,30 @@ Watch the source file or directory, recompiling when any file changes.
 
 #### `--version`
 Output the current version.
+
+### Configurationfile `.baileyrc`
+Bailey.js has support for configuration through a json file called `.baileyrc`.
+It can be used in order to shorten the parse command or to define several
+configurations for a project. This can often be the use case in an web project
+with a node or io.js backend. The configuration file can define multiple sets
+of options like the example below. Any options passed in the cli will override
+the configuration file and if positional arguments are passed in the cli bailey
+will not read the configuration file.
+
+{% highlight json %}
+{
+  "server": {
+    "source": "src/server",
+    "target": "dist/server",
+    "node": true
+  },
+  "frontend": {
+    "source": "src/frontend",
+    "target": "dist/server/public"
+  }
+}
+{% endhighlight %}
+
+The example above will compile the server code as node and the frontend code
+as require.js when you run `bailey`. It is also possible to run `bailey -c frontend`
+or `bailey --config frontend` in order to compile only the frontend code.

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,11 @@ var bailey = require('./../bailey'),
     program = require('commander'),
     fs = require('fs');
 
+var EXIT_CODES = {
+    PARSER_ERROR: 1,
+    CONFIGURATION_ERROR: 2
+};
+
 program
     .version(bailey.version)
     .usage('<source> <target>')
@@ -37,6 +42,7 @@ function runTasks(program) {
         } catch (err) {
             console.error('Could not parse .baileyrc'.red)
             console.error(err.toString().red);
+            process.exit(EXIT_CODES.CONFIGURATION_ERROR);
         }
         if (program.config) {
             configs = program.config.split(',');
@@ -73,7 +79,7 @@ function runTask(program, options, configFromFile) {
     compile(options.source, options.target, options, function () {
         if (program.watch) startWatching(options);
     }, function (err) {
-        process.exit(1);
+        process.exit(EXIT_CODES.PARSER_ERROR);
     });
 }
 
@@ -94,7 +100,7 @@ function parseStringOrPrintError(string, options) {
     }
     catch (e) {
         console.error(e.toString().red);
-        process.exit(1);
+        process.exit(EXIT_CODES.PARSER_ERROR);
     }
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
-
 var bailey = require('./../bailey'),
     watch = require('node-watch'),
-    program = require('commander');
+    program = require('commander'),
+    fs = require('fs');
 
 program
     .version(bailey.version)
@@ -14,54 +14,70 @@ program
     .option('--carebear', 'Do not care about style guide errors. Shame on you.')
     .option('--optimize', 'Remove debug checks for types (types are experimental)')
     .option('--eval [input]', '')
+    .option('-c, --config [input]', 'Configs you want to run, seperated by comma.')
     .option('--stdio', '')
     .parse(process.argv);
 
-var options = {
-    node: !!program.node,
-    removeComments: !!program['remove-comments'],
-    strictStyleMode: !program['carebear'],
-    optimize: !!program['optimize'],
-    bare: !!program.bare,
-};
+runTasks(program);
 
-if (program.stdio) {
-    process.stdin.setEncoding('utf8');
+function runTasks(program) {
+    var baileyrcPath = process.cwd() + '/.baileyrc';
+    var options = {
+        node: false,
+        bare: false,
+        removeComments: false,
+        strictStyleMode: true,
+        optimize: false,
+        config: 'default'
+    };
 
-    process.stdin.on('readable', function() {
-        parseStringOrPrintError(process.stdin.read() || '');
-    });
-
-    process.stdin.resume();
-    return;
-}
-
-if (program.eval) {
-    return parseStringOrPrintError(program.eval);
-}
-
-if (program.args.length != 2) {
-    program.help();
-}
-
-var source = program.args[0];
-var target = program.args[1];
-
-if (!source || !target) {
-     program.help();
-}
-
-function parseStringOrPrintError(string) {
-    try {
-        return console.log(bailey.parseString(string, options));
+    if (!program.args.length && fs.existsSync(baileyrcPath)) {
+        try {
+            var baileyrc = JSON.parse(fs.readFileSync(baileyrcPath));
+        } catch (err) {
+            console.error('Could not parse .baileyrc'.red)
+            console.error(err.toString().red);
+        }
+        if (program.config) {
+            configs = program.config.split(',');
+            configs.forEach(function(config) {
+                runTask(program, options, baileyrc[configs]);
+            })
+        } else {
+            for (var key in baileyrc) {
+                runTask(program, options, baileyrc[key]);
+            }
+        }
+    } else {
+        options.source = program.args[0];
+        options.target = program.args[1];
+        runTask(program, options, {});
     }
-    catch (e) {
-        console.error(e.toString().red);
+}
+
+function runTask(program, options, configFromFile) {
+    for (var key in configFromFile) {
+        options[key] = configFromFile[key];
+    }
+
+    if (program.node) options.node = true;
+    if (program.bare) options.bare = true;
+    if (program.removeComments) options.removeComments = true;
+    if (program.carebear) options.strictStyleMode = false;
+    if (program.optimize) options.optimize = true;
+
+    if (program.stdio) return stdio(options);
+    if (program.eval) return parseStringOrPrintError(program.eval, options);
+    if (!options.source || !options.target) return program.help();
+
+    compile(options.source, options.target, options, function () {
+        if (program.watch) startWatching(options);
+    }, function (err) {
         process.exit(1);
-    }
+    });
 }
 
-function compile(onDone, onError) {
+function compile(source, target, options, onDone, onError) {
     bailey.parseFiles(source, target, options, function(sourcePath, targetPath) {
         if (program.verbose) {
             console.log(sourcePath, "->", targetPath);
@@ -72,23 +88,33 @@ function compile(onDone, onError) {
     }, onDone);
 }
 
-function startWatching () {
+function parseStringOrPrintError(string, options) {
+    try {
+        return console.log(bailey.parseString(string, options));
+    }
+    catch (e) {
+        console.error(e.toString().red);
+        process.exit(1);
+    }
+}
+
+function startWatching(options) {
     program.verbose = true;
-    console.log('Watching ' + source + ' for changes...');
-    watch(source, function(filename) {
+    console.log('Watching ' + options.source + ' for changes...');
+    watch(options.source, function(filename) {
         if (/(\.bs|\.bailey)$/.test(filename)) {
             console.log('\n' + filename + ' changed, recompiling...\n-----------');
-            compile(function(){
+            compile(options.source, options.target, options, function(){
                 console.log('-----------\nDone! Looking for more changes...');
             });
         }
     });
 }
 
-compile(function () {
-    if (program.watch) {
-        startWatching();
-    }
-}, function (err) {
-    process.exit(1);
-});
+function stdio(options) {
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('readable', function() {
+        parseStringOrPrintError(process.stdin.read() || '', options);
+    });
+    process.stdin.resume();
+}


### PR DESCRIPTION
Add support for a `.baileyrc` on the following form:
```
{
  "server": {
    "source": "src/server",
    "target": "dist/server",
    "node": true
  },
  "frontend": {
    "source": "src/frontend",
    "target": "dist/frontend",
  }
}
```
This makes it possible to run `bailey` to parse both or `bailey -c
server` to only parse the server files

Closes #78