### PR TITLE
Fix naming functions on objects

### DIFF
--- a/.baileyrc
+++ b/.baileyrc
@@ -8,5 +8,10 @@
     "source": "test",
     "target": "test",
     "node": true
+  },
+  "tests-fixtures": {
+    "source": "test/fixtures",
+    "target": "test/fixtures",
+    "node": true
   }
 }

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -802,6 +802,12 @@
                 return p.toJS();
             })
 
+            if(typeof this.name === 'object') {
+              if (this.name.nodeType === 'PropertyAccess') {
+                this.name = this.name.accessor.name;
+              }
+            }
+
             return 'function' + (this.name ? ' ' + this.name : '') +
                    '(' + params.join(', ') + ') {\n' + this.body.toJS() + '}';
         }

--- a/test/fixtures/functions.bs
+++ b/test/fixtures/functions.bs
@@ -1,0 +1,11 @@
+a = {
+  iceCream: (n) -> 2 * n
+  chocolate: (n) ->
+    return 5 * n
+}
+
+a.caramel = (n) -> n
+a.cookies = (n) ->
+  return n + 1
+
+a.iceCream(5) + a.chocolate(10) + a.caramel(10) + a.cookies(1)

--- a/test/fixtures/functions.bs
+++ b/test/fixtures/functions.bs
@@ -8,4 +8,4 @@ a.caramel = (n) -> n
 a.cookies = (n) ->
   return n + 1
 
-a.iceCream(5) + a.chocolate(10) + a.caramel(10) + a.cookies(1)
+a.iceCream(5) + a.chocolate(4) + a.caramel(10) + a.cookies(1)


### PR DESCRIPTION
This fixes the issue where this:
```coffeescript
a.cookies = (n) ->
  return n + 1
```
is turned into:
```javascript
a.cookies = function [object Object](n) {
    return n + 1;
};
```
and makes it into this instead:
```javascript
a.cookies = function cookies(n) {
    return n + 1;
};
```