### PR TITLE
Fix #84, Add node_modules to walker ignore

### DIFF
--- a/src/compiler-node.js
+++ b/src/compiler-node.js
@@ -39,7 +39,8 @@ function parseFiles (source, target, options, onFile, onError, onDone) {
 
     // It's a directory, let's walk though it all
     var walker = walk.walk(source, {
-        followLinks: false
+        followLinks: false,
+        filters: ['node_modules']
     });
 
     // From here on we need a ./ from the start to be removed


### PR DESCRIPTION
Before:
```
time ./bailey.js ./ ./ 
./bailey.js ./ ./  1.93s user 0.72s system 23% cpu 11.126 total
```

After:
```
 time ./bailey.js ./ ./
./bailey.js ./ ./  0.68s user 0.08s system 79% cpu 0.954 total
```