### PR TITLE
Add browser field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.16",
   "description": "A coffeescript without that bitter after-taste.",
   "main": "bailey.js",
+  "browser": "./src/compiler.js",
   "dependencies": {
     "colors": "*",
     "commander": "^2.2.0",


### PR DESCRIPTION
This makes it possible to use npm install and require('bailey') with
browserify.