### PR TITLE
Add istanbul ignore next above not new check

### DIFF
--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -518,7 +518,7 @@
         toJS: function () {
             var name = this.name;
             var out = 'function ' + this.name + ' ';
-            var errorIfNotNewed = 'if ((typeof window !== "undefined" && this === window) || (typeof self !== "undefined" && this === self)) { throw new TypeError("Tried to call class ' + name + ' as a regular function. Classes can only be called with the \'new\' keyword."); }';
+            var errorIfNotNewed = '\n/* istanbul ignore next */\nif ((typeof window !== "undefined" && this === window) || (typeof self !== "undefined" && this === self)) { throw new TypeError("Tried to call class ' + name + ' as a regular function. Classes can only be called with the \'new\' keyword."); }';
             if (this.init !== null) {
                 var params = this.init.params.map(function(p) {
                     return p.toJS();


### PR DESCRIPTION
Candy in examples/classes.bs will look like this
```javascript
function Candy(title, price, quantity) {
    /* istanbul ignore next  */
    if ((typeof window !== "undefined" && this === window) || (typeof self !== "undefined" && this === self)) {
        throw new TypeError("Tried to call class Candy as a regular function. Classes can only be called with the 'new' keyword.");
    }
    this.title = title;
    this.price = price;
    this.quantity = quantity;
    this.slug = slugify(title);
}
```