### PR TITLE
Add setting of constructor when extending a class

### DIFF
--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -532,6 +532,7 @@
 
             if (this.extendFrom) {
                 out += this.name + '.prototype = Object.create(' + this.extendFrom + '.prototype);'
+                out += this.name + '.prototype.constructor = ' + this.name + ';'
             }
 
             out += this.values.map(function(item) {


### PR DESCRIPTION
This adds 

```
Chocolate.prototype.constructor = Chocolate;
```

when a class is extended.

---

Excerpt from compiled version of examples/classes.bs

``` javascript
function Chocolate(title, price, quantity, type) {
    if ((typeof window !== "undefined" && this === window) || (typeof self !== "undefined" && this === self)) {
        throw new TypeError("Tried to call class Chocolate as a regular function. Classes can only be called with the 'new' keyword.");
    }
    Candy.call(this, title, price, quantity);
    this.type = type;
}
Chocolate.prototype = Object.create(Candy.prototype);
Chocolate.prototype.constructor = Chocolate;
```
